### PR TITLE
Update to game API v1.0.12

### DIFF
--- a/game.moonlight/addon.xml
+++ b/game.moonlight/addon.xml
@@ -5,7 +5,7 @@
   name="Moonlight Client"
   provider-name="acmiyaguchi">
   <requires>
-    <import addon="kodi.game" version="1.0.0"/>
+    <import addon="kodi.game" version="1.0.12"/>
   </requires>
   <extension point="kodi.gameclient"
     library_android="game.moonlight.so"

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -205,61 +205,6 @@ bool InputEvent(unsigned int port, const game_input_event* event)
   return false;
 }
 
-GAME_ERROR DiskSetEjectState(GAME_EJECT_STATE ejected)
-{
-  return GAME_ERROR_FAILED;
-}
-
-GAME_EJECT_STATE DiskGetEjectState(void)
-{
-  return GAME_NOT_EJECTED;
-}
-
-unsigned DiskGetImageIndex(void)
-{
-  return 0;
-}
-
-GAME_ERROR DiskSetImageIndex(unsigned index)
-{
-  return GAME_ERROR_FAILED;
-}
-
-unsigned DiskGetNumImages(void)
-{
-  return 0;
-}
-
-GAME_ERROR DiskReplaceImageIndex(unsigned index, const char* url)
-{
-  return GAME_ERROR_FAILED;
-}
-
-GAME_ERROR DiskAddImageIndex(void)
-{
-  return GAME_ERROR_FAILED;
-}
-
-GAME_ERROR CameraInitialized(void)
-{
-  return GAME_ERROR_FAILED;
-}
-
-GAME_ERROR CameraDeinitialized(void)
-{
-  return GAME_ERROR_FAILED;
-}
-
-GAME_ERROR CameraFrameRawBuffer(const uint32_t* buffer, unsigned width, unsigned height, size_t pitch)
-{
-  return GAME_ERROR_FAILED;
-}
-
-GAME_ERROR CameraFrameOpenglTexture(unsigned texture_id, unsigned texture_target, const float* affine)
-{
-  return GAME_ERROR_FAILED;
-}
-
 size_t SerializeSize(void)
 {
   return 0;


### PR DESCRIPTION
Made some changes to the game API (see https://github.com/garbear/xbmc/commits/retroplayer-15beta2). Only thing that affects this add-on is the removal of some functions

you should merge this once you update your Kodi tree. I recommend a hard reset to the latest `retroplayer-15beta2`, and then cherry-pick https://github.com/garbear/xbmc/commit/16393de. this commit is the 4 commits from https://github.com/garbear/xbmc/pull/37 squashed into a single commit. You can then force-push to your `retroplayer-h264` and the PR will be updated with the squashed commit.
